### PR TITLE
auth: add maintainer info to index and lockout

### DIFF
--- a/tjdests/apps/authentication/views.py
+++ b/tjdests/apps/authentication/views.py
@@ -65,3 +65,14 @@ def accept_tos_view(request: HttpRequest) -> HttpResponse:
     context = {"form": form}
 
     return render(request, "authentication/accept_tos.html", context=context)
+
+
+def lockout(request, *args, **kwargs):
+    return HttpResponse(
+        (
+            "Your account has been locked due to too many failed login attempts, ",
+            f"please contact {settings.MAINTAINER} for assistance ",
+            "<i>or remember your password next time!</i>",
+        ),
+        status=403,
+    )

--- a/tjdests/settings/__init__.py
+++ b/tjdests/settings/__init__.py
@@ -124,6 +124,9 @@ AUTHENTICATION_BACKENDS = (
     "django.contrib.auth.backends.ModelBackend",
 )
 
+AXES_LOCKOUT_CALLABLE = "tjdests.apps.authentication.views.lockout"
+MAINTAINER = ""
+
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 SOCIAL_AUTH_ION_KEY = ""
 SOCIAL_AUTH_ION_SECRET = ""

--- a/tjdests/templates/authentication/index.html
+++ b/tjdests/templates/authentication/index.html
@@ -30,8 +30,9 @@
     </p>
     <p>
         This website is <a href="https://github.com/etnguyen03/tjdests" target="_blank">open source</a>,
-        and is © 2021 <a href="https://github.com/etnguyen03/tjdests/graphs/contributors" target="_blank">Ethan Nguyen and contributors</a>.
-        All rights reserved.
+        and is currently maintained by {{ settings.MAINTAINER }}<br>
+        <small>© 2021 <a href="https://github.com/etnguyen03/tjdests/graphs/contributors" target="_blank">Ethan Nguyen and contributors</a>.
+        All rights reserved.</small>
     </p>
 
 {% endblock %}


### PR DESCRIPTION
Add maintainer information to index page along with lockout page for `django-axes` so that users have more information