### PR TITLE
feat: make setup easier

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cd /site/public
+git pull
+TMPDIR=/site/tmp pipenv sync
+pipenv run ./manage.py migrate
+pipenv run ./manage.py collectstatic --no-input
+echo "Deploy complete. Restart the site process to wrap up."

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pipenv run gunicorn -b $HOST:$PORT --workers 4 tjdests.wsgi

--- a/tjdests/settings/secret.sample.py
+++ b/tjdests/settings/secret.sample.py
@@ -18,9 +18,34 @@ SECRET_KEY = "supersecret"
 SOCIAL_AUTH_ION_KEY = "ionkey"
 SOCIAL_AUTH_ION_SECRET = "ionsecret"
 
+# Database
+# DATABASES = {
+#     "default": {
+#         "ENGINE": "django.db.backends.postgresql",
+#         "NAME": os.environ["DIRECTOR_DATABASE_NAME"],
+#         "USER": os.environ["DIRECTOR_DATABASE_USERNAME"],
+#         "PASSWORD": os.environ["DIRECTOR_DATABASE_PASSWORD"],
+#         "HOST": os.environ["DIRECTOR_DATABASE_HOST"],
+#         "PORT": os.environ["DIRECTOR_DATABASE_PORT"],
+#     },
+# }
+
+# Axes
+# AXES_META_PRECEDENCE_ORDER = [
+#     'HTTP_X_REAL_IP',
+# ]
+# AXES_NEVER_LOCKOUT_WHITELIST = True
+# AXES_IP_WHITELIST = ["151.188.227.237"]
+
 # Message blast - treated as HTML safe text
 # type is str
 GLOBAL_MESSAGE = None
+# GLOBAL_MESSAGE = "<b>WARNING</b>: This is not ready for production usage! Any and all data may be deleted at any time without warning!"
 
 # Login lock: if True, restrict login to superusers only
 LOGIN_LOCKED = False
+
+TIME_ZONE = "America/New_York"
+
+# To prevent Git issues
+MAINTAINER = "First Last (20XXusername)"


### PR DESCRIPTION
- Add a Director-compatible `run.sh`
- Add `deploy.sh`
- Add production defaults to `secret.sample.py` 